### PR TITLE
persist: use serialised folder names as the persist folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ These would then be used with either `folderbox /path/to/my-project` or `folderb
 
 # Persistence
 
-The `$HOME` folder in the container is stored for each folderbox in `~/.local/share/com.ahayzen.folderbox/persist/<boxname>`,
+The `$HOME` folder in the container is stored for each folderbox in `~/.local/share/com.ahayzen.folderbox/persist/<boxname>-<cksum of project>-<basename of project>`,
 this allows for user installs, repositories, configuration, and bash history to be preserved between sessions.
 
 Note that the container itself is removed once it is stopped, so if packages or changes to the root

--- a/src/folders/persist.sh
+++ b/src/folders/persist.sh
@@ -3,6 +3,12 @@
 # SPDX-License-Identifier: MPL-2.0
 
 function folders_setup_persist() {
-    # TODO: serialise the folder name too
-    PERSIST_FOLDER="$DATA_FOLDER/persist/$BOX_NAME"
+    # Build a serialised name for the persist folder
+    # this is a combination of the box name and work folder name
+    local base_name
+    local serialised
+    base_name=$(basename "$WORK_FOLDER")
+    serialised=$(echo "$WORK_FOLDER" | cksum | cut -d' ' -f1)
+
+    PERSIST_FOLDER="$DATA_FOLDER/persist/${BOX_NAME}-${serialised}-${base_name}"
 }


### PR DESCRIPTION
This means that two projects using the same box don't collide.